### PR TITLE
[HOTFIX] [REVIEW] Updating XGBoost DMatrix Logic to Accept cuDF Objects with new Cython Interface

### DIFF
--- a/python-package/xgboost/compat.py
+++ b/python-package/xgboost/compat.py
@@ -64,7 +64,7 @@ except ImportError:
 
     class CUDF_CPP(object):
         """ dummy object for cudf.bindings.cudf_cpp """
-        def column_view_handle(self, object):
+        def column_view_handle(self, *args, **kwargs):
             """ dummy function for extracting cuDF column handle """
             return
         pass

--- a/python-package/xgboost/compat.py
+++ b/python-package/xgboost/compat.py
@@ -50,7 +50,7 @@ except ImportError:
 try:
     from cudf.dataframe import DataFrame as CUDF
     from cudf.dataframe.column import Column as CUDF_COL
-    from libgdf_cffi import ffi as CUDF_FFI
+    from cudf.bindings import cudf_cpp as CUDF_CPP
     CUDF_INSTALLED = True
 except ImportError:
 
@@ -62,13 +62,12 @@ except ImportError:
         """ dummy object for cudf.dataframe.column.Column """
         pass
 
-    class CUDF_FFI(object):
-        """ dummy object for libgdf_cffi.ffi ... FFI bindings to cudf """
-        def new(self, *args, **kwargs):
-            pass
-
-        def cast(self, *args, **kwargs):
-            pass
+    class CUDF_CPP(object):
+        """ dummy object for cudf.bindings.cudf_cpp """
+        def column_view_handle(self, object):
+            """ dummy function for extracting cuDF column handle """
+            return
+        pass
 
     CUDF_INSTALLED = False
 

--- a/python-package/xgboost/compat.py
+++ b/python-package/xgboost/compat.py
@@ -50,7 +50,6 @@ except ImportError:
 try:
     from cudf.dataframe import DataFrame as CUDF
     from cudf.dataframe.column import Column as CUDF_COL
-    from cudf.bindings import cudf_cpp as CUDF_CPP
     CUDF_INSTALLED = True
 except ImportError:
 
@@ -60,13 +59,6 @@ except ImportError:
 
     class CUDF_COL(object):
         """ dummy object for cudf.dataframe.column.Column """
-        pass
-
-    class CUDF_CPP(object):
-        """ dummy object for cudf.bindings.cudf_cpp """
-        def column_view_handle(self, *args, **kwargs):
-            """ dummy function for extracting cuDF column handle """
-            return
         pass
 
     CUDF_INSTALLED = False

--- a/python-package/xgboost/core.py
+++ b/python-package/xgboost/core.py
@@ -19,7 +19,7 @@ import warnings
 import numpy as np
 import scipy.sparse
 
-from .compat import (STRING_TYPES, PY3, DataFrame, CUDF, CUDF_COL, CUDF_CPP, MultiIndex, py_str,
+from .compat import (STRING_TYPES, PY3, DataFrame, CUDF, CUDF_COL, MultiIndex, py_str,
                      PANDAS_INSTALLED, DataTable)
 from .libpath import find_lib_path
 
@@ -436,7 +436,7 @@ class DMatrix(object):
         Initialize data from a GPU data frame.
         """
         self.handle = ctypes.c_void_p()
-        col_ptrs = [ctypes.c_void_p(CUDF_CPP.column_view_handle(df[col]._column)) for col in df.columns]
+        col_ptrs = [ctypes.c_void_p(df[col]._column._handle) for col in df.columns]
         col_ptr_arr = (ctypes.c_void_p * len(col_ptrs))(*col_ptrs)
         _check_call(_LIB.XGDMatrixCreateFromCUDF
                     (col_ptr_arr,
@@ -641,9 +641,9 @@ class DMatrix(object):
     def set_cudf_info(self, field, data):
         col_ptrs = []
         if isinstance(data, CUDF):
-            col_ptrs = [ctypes.c_void_p(CUDF_CPP.column_view_handle(data[col]._column)) for col in data.columns]
+            col_ptrs = [ctypes.c_void_p(data[col]._column._handle) for col in data.columns]
         else:
-            col_ptrs = [ctypes.c_void_p(CUDF_CPP.column_view_handle(data._column))]
+            col_ptrs = [ctypes.c_void_p(data._column._handle)]
         col_ptr_arr = (ctypes.c_void_p * len(col_ptrs))(*col_ptrs)
         _check_call(_LIB.XGDMatrixSetCUDFInfo
                     (self.handle, c_str(field),

--- a/python-package/xgboost/core.py
+++ b/python-package/xgboost/core.py
@@ -436,7 +436,7 @@ class DMatrix(object):
         Initialize data from a GPU data frame.
         """
         self.handle = ctypes.c_void_p()
-        col_ptrs = [ctypes.c_void_p(df[col]._column._handle) for col in df.columns]
+        col_ptrs = [ctypes.c_void_p(df[col]._column._pointer) for col in df.columns]
         col_ptr_arr = (ctypes.c_void_p * len(col_ptrs))(*col_ptrs)
         _check_call(_LIB.XGDMatrixCreateFromCUDF
                     (col_ptr_arr,
@@ -641,9 +641,9 @@ class DMatrix(object):
     def set_cudf_info(self, field, data):
         col_ptrs = []
         if isinstance(data, CUDF):
-            col_ptrs = [ctypes.c_void_p(data[col]._column._handle) for col in data.columns]
+            col_ptrs = [ctypes.c_void_p(data[col]._column._pointer) for col in data.columns]
         else:
-            col_ptrs = [ctypes.c_void_p(data._column._handle)]
+            col_ptrs = [ctypes.c_void_p(data._column._pointer)]
         col_ptr_arr = (ctypes.c_void_p * len(col_ptrs))(*col_ptrs)
         _check_call(_LIB.XGDMatrixSetCUDFInfo
                     (self.handle, c_str(field),

--- a/tests/cpp/tree/test_gpu_hist.cu
+++ b/tests/cpp/tree/test_gpu_hist.cu
@@ -61,8 +61,6 @@ void BuildGidx(DeviceShard<GradientSumT>* shard, int n_rows, int n_cols,
                bst_float sparsity=0) {
   auto dmat = CreateDMatrix(n_rows, n_cols, sparsity, 3);
   const SparsePage& batch = *(*dmat)->GetRowBatches().begin();
-  GPUSet devices = GPUSet::Range(0, 1);
-  batch.offset.Reshard(GPUDistribution::Overlap(devices, 1));
 
   common::HistCutMatrix cmat;
   cmat.row_ptr = {0, 3, 6, 9, 12, 15, 18, 21, 24};

--- a/tests/python-gpu/test_gpu_gdf.py
+++ b/tests/python-gpu/test_gpu_gdf.py
@@ -5,7 +5,6 @@ try:
 except ImportError as e:
     print("Failed to import cuDF: " + str(e))
     print("Skipping this test")
-    return 0
 from sklearn import datasets
 import sys
 import unittest


### PR DESCRIPTION
Changed the pointer cast from `cudf.DataFrame._column` type to use `ctypes` ~and the new `cudf.bindings.cudf_cpp` module~.

Preferred the use of `cudf.DataFrame._column._handle` as this API is expected to be more stable.