### PR TITLE
Include `cpack` to generate source packages

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -255,6 +255,8 @@ if (BUILD_C_DOC)
   run_doxygen()
 endif (BUILD_C_DOC)
 
+include(CPack)
+
 include(GNUInstallDirs)
 # Install all headers.  Please note that currently the C++ headers does not form an "API".
 install(DIRECTORY ${xgboost_SOURCE_DIR}/include/xgboost


### PR DESCRIPTION
This PR adds `include(CPack)` to CMakeLists.txt to support generating source packages for `xgboost`.

Backport of https://github.com/dmlc/xgboost/pull/7160

cc: @trxcllnt