### PR TITLE
Add missing Thrust header includes.

### DIFF
--- a/src/common/device_helpers.cuh
+++ b/src/common/device_helpers.cuh
@@ -16,6 +16,21 @@
 #include <thrust/gather.h>
 #include <thrust/unique.h>
 #include <thrust/binary_search.h>
+#include <thrust/copy.h>
+#include <thrust/fill.h>
+#include <thrust/functional.h>
+#include <thrust/iterator/counting_iterator.h>
+#include <thrust/iterator/iterator_traits.h>
+#include <thrust/iterator/reverse_iterator.h>
+#include <thrust/iterator/transform_iterator.h>
+#include <thrust/pair.h>
+#include <thrust/reduce.h>
+#include <thrust/scan.h>
+#include <thrust/scatter.h>
+#include <thrust/sequence.h>
+#include <thrust/sort.h>
+#include <thrust/transform.h>
+#include <thrust/tuple.h>
 
 #include <rabit/rabit.h>
 #include <cub/cub.cuh>

--- a/src/common/hist_util.cu
+++ b/src/common/hist_util.cu
@@ -13,6 +13,7 @@
 #include <thrust/sort.h>
 #include <thrust/binary_search.h>
 #include <thrust/execution_policy.h>
+#include <thrust/scan.h>
 
 #include <memory>
 #include <mutex>

--- a/src/common/hist_util.cuh
+++ b/src/common/hist_util.cuh
@@ -8,6 +8,13 @@
 #define COMMON_HIST_UTIL_CUH_
 
 #include <thrust/host_vector.h>
+#include <thrust/copy.h>
+#include <thrust/execution_policy.h>
+#include <thrust/extrema.h>
+#include <thrust/iterator/constant_iterator.h>
+#include <thrust/iterator/counting_iterator.h>
+#include <thrust/scan.h>
+#include <thrust/sort.h>
 
 #include "hist_util.h"
 #include "quantile.cuh"

--- a/src/common/quantile.cu
+++ b/src/common/quantile.cu
@@ -6,6 +6,17 @@
 #include <thrust/iterator/discard_iterator.h>
 #include <thrust/transform_scan.h>
 #include <thrust/unique.h>
+#include <thrust/copy.h>
+#include <thrust/functional.h>
+#include <thrust/iterator/constant_iterator.h>
+#include <thrust/iterator/counting_iterator.h>
+#include <thrust/iterator/reverse_iterator.h>
+#include <thrust/iterator/zip_iterator.h>
+#include <thrust/merge.h>
+#include <thrust/reduce.h>
+#include <thrust/scan.h>
+#include <thrust/transform.h>
+#include <thrust/tuple.h>
 
 #include <limits>  // std::numeric_limits
 #include <memory>

--- a/src/common/quantile.cuh
+++ b/src/common/quantile.cuh
@@ -1,6 +1,10 @@
 #ifndef XGBOOST_COMMON_QUANTILE_CUH_
 #define XGBOOST_COMMON_QUANTILE_CUH_
 
+#include <thrust/execution_policy.h>
+#include <thrust/functional.h>
+#include <thrust/logical.h>
+
 #include <memory>
 
 #include "xgboost/span.h"

--- a/src/data/data.cu
+++ b/src/data/data.cu
@@ -4,6 +4,13 @@
  * \file data.cu
  * \brief Handles setting metainfo from array interface.
  */
+
+#include <thrust/copy.h>
+#include <thrust/execution_policy.h>
+#include <thrust/iterator/counting_iterator.h>
+#include <thrust/logical.h>
+#include <thrust/scan.h>
+
 #include "xgboost/data.h"
 #include "xgboost/logging.h"
 #include "xgboost/json.h"

--- a/src/data/device_adapter.cuh
+++ b/src/data/device_adapter.cuh
@@ -4,6 +4,11 @@
  */
 #ifndef XGBOOST_DATA_DEVICE_ADAPTER_H_
 #define XGBOOST_DATA_DEVICE_ADAPTER_H_
+
+#include <thrust/device_ptr.h>
+#include <thrust/execution_policy.h>
+#include <thrust/functional.h>
+
 #include <limits>
 #include <memory>
 #include <string>

--- a/src/data/ellpack_page.cu
+++ b/src/data/ellpack_page.cu
@@ -4,6 +4,13 @@
 #include <xgboost/data.h>
 #include <thrust/iterator/discard_iterator.h>
 #include <thrust/iterator/transform_output_iterator.h>
+#include <thrust/binary_search.h>
+#include <thrust/copy.h>
+#include <thrust/execution_policy.h>
+#include <thrust/fill.h>
+#include <thrust/iterator/counting_iterator.h>
+#include <thrust/iterator/zip_iterator.h>
+#include <thrust/tuple.h>
 #include "../common/categorical.h"
 #include "../common/hist_util.cuh"
 #include "../common/random.h"

--- a/src/data/ellpack_page.cuh
+++ b/src/data/ellpack_page.cuh
@@ -12,6 +12,7 @@
 #include "../common/hist_util.h"
 #include "../common/categorical.h"
 #include <thrust/binary_search.h>
+#include <thrust/execution_policy.h>
 
 namespace xgboost {
 /** \brief Struct for accessing and manipulating an ELLPACK matrix on the

--- a/src/data/iterative_device_dmatrix.cu
+++ b/src/data/iterative_device_dmatrix.cu
@@ -1,6 +1,10 @@
 /*!
  * Copyright 2020 XGBoost contributors
  */
+
+#include <thrust/execution_policy.h>
+#include <thrust/reduce.h>
+
 #include <memory>
 #include <type_traits>
 #include <algorithm>

--- a/src/data/simple_dmatrix.cuh
+++ b/src/data/simple_dmatrix.cuh
@@ -8,6 +8,9 @@
 #include <thrust/copy.h>
 #include <thrust/scan.h>
 #include <thrust/execution_policy.h>
+#include <thrust/device_ptr.h>
+#include <thrust/iterator/counting_iterator.h>
+#include <thrust/iterator/transform_iterator.h>
 #include "device_adapter.cuh"
 #include "../common/device_helpers.cuh"
 

--- a/src/linear/updater_gpu_coordinate.cu
+++ b/src/linear/updater_gpu_coordinate.cu
@@ -5,6 +5,9 @@
 
 #include <thrust/execution_policy.h>
 #include <thrust/inner_product.h>
+#include <thrust/iterator/counting_iterator.h>
+#include <thrust/iterator/permutation_iterator.h>
+#include <thrust/iterator/transform_iterator.h>
 #include <xgboost/data.h>
 #include <xgboost/linear_updater.h>
 #include "xgboost/span.h"

--- a/src/metric/auc.cu
+++ b/src/metric/auc.cu
@@ -2,6 +2,19 @@
  * Copyright 2021 by XGBoost Contributors
  */
 #include <thrust/scan.h>
+#include <thrust/binary_search.h>
+#include <thrust/copy.h>
+#include <thrust/count.h>
+#include <thrust/execution_policy.h>
+#include <thrust/functional.h>
+#include <thrust/iterator/counting_iterator.h>
+#include <thrust/iterator/discard_iterator.h>
+#include <thrust/iterator/transform_output_iterator.h>
+#include <thrust/logical.h>
+#include <thrust/pair.h>
+#include <thrust/reduce.h>
+#include <thrust/tuple.h>
+#include <thrust/unique.h>
 #include <cub/cub.cuh>
 
 #include <algorithm>

--- a/src/metric/rank_metric.cu
+++ b/src/metric/rank_metric.cu
@@ -10,6 +10,11 @@
 #include <xgboost/metric.h>
 #include <xgboost/host_device_vector.h>
 #include <thrust/iterator/discard_iterator.h>
+#include <thrust/execution_policy.h>
+#include <thrust/iterator/counting_iterator.h>
+#include <thrust/reduce.h>
+#include <thrust/scan.h>
+#include <thrust/transform.h>
 
 #include <cmath>
 #include <array>

--- a/src/metric/survival_metric.cu
+++ b/src/metric/survival_metric.cu
@@ -22,6 +22,9 @@
 
 #if defined(XGBOOST_USE_CUDA)
 #include <thrust/execution_policy.h>  // thrust::cuda::par
+#include <thrust/functional.h>
+#include <thrust/iterator/counting_iterator.h>
+#include <thrust/transform_reduce.h>
 #include "../common/device_helpers.cuh"
 #endif  // XGBOOST_USE_CUDA
 

--- a/src/objective/rank_obj.cu
+++ b/src/objective/rank_obj.cu
@@ -21,6 +21,16 @@
 #include <thrust/iterator/discard_iterator.h>
 #include <thrust/random/uniform_int_distribution.h>
 #include <thrust/random/linear_congruential_engine.h>
+#include <thrust/binary_search.h>
+#include <thrust/execution_policy.h>
+#include <thrust/extrema.h>
+#include <thrust/functional.h>
+#include <thrust/iterator/counting_iterator.h>
+#include <thrust/iterator/transform_iterator.h>
+#include <thrust/reduce.h>
+#include <thrust/scan.h>
+#include <thrust/swap.h>
+#include <thrust/transform.h>
 
 #include <cub/util_allocator.cuh>
 

--- a/src/predictor/gpu_predictor.cu
+++ b/src/predictor/gpu_predictor.cu
@@ -6,6 +6,12 @@
 #include <thrust/device_vector.h>
 #include <thrust/fill.h>
 #include <thrust/host_vector.h>
+#include <thrust/execution_policy.h>
+#include <thrust/extrema.h>
+#include <thrust/iterator/counting_iterator.h>
+#include <thrust/logical.h>
+#include <thrust/scan.h>
+#include <thrust/swap.h>
 #include <GPUTreeShap/gpu_treeshap.h>
 #include <memory>
 

--- a/src/tree/constraints.cu
+++ b/src/tree/constraints.cu
@@ -5,6 +5,8 @@
 #include <thrust/device_vector.h>
 #include <thrust/execution_policy.h>
 #include <thrust/iterator/counting_iterator.h>
+#include <thrust/device_ptr.h>
+#include <thrust/fill.h>
 
 #include <algorithm>
 #include <string>

--- a/src/tree/gpu_hist/evaluate_splits.cu
+++ b/src/tree/gpu_hist/evaluate_splits.cu
@@ -1,6 +1,10 @@
 /*!
  * Copyright 2020-2022 by XGBoost Contributors
  */
+#include <thrust/execution_policy.h>
+#include <thrust/for_each.h>
+#include <thrust/iterator/counting_iterator.h>
+
 #include <algorithm>  // std::max
 #include <limits>
 

--- a/src/tree/gpu_hist/evaluate_splits.cuh
+++ b/src/tree/gpu_hist/evaluate_splits.cuh
@@ -4,6 +4,7 @@
 #ifndef EVALUATE_SPLITS_CUH_
 #define EVALUATE_SPLITS_CUH_
 #include <thrust/system/cuda/experimental/pinned_allocator.h>
+#include <thrust/tuple.h>
 #include <xgboost/span.h>
 
 #include "../../common/categorical.h"

--- a/src/tree/gpu_hist/evaluator.cu
+++ b/src/tree/gpu_hist/evaluator.cu
@@ -6,6 +6,10 @@
  */
 #include <thrust/logical.h>  // thrust::any_of
 #include <thrust/sort.h>     // thrust::stable_sort
+#include <thrust/execution_policy.h>
+#include <thrust/iterator/counting_iterator.h>
+#include <thrust/transform.h>
+#include <thrust/tuple.h>
 
 #include "../../common/device_helpers.cuh"
 #include "../../common/hist_util.h"  // common::HistogramCuts

--- a/src/tree/gpu_hist/gradient_based_sampler.cu
+++ b/src/tree/gpu_hist/gradient_based_sampler.cu
@@ -4,6 +4,16 @@
 #include <thrust/functional.h>
 #include <thrust/random.h>
 #include <thrust/transform.h>
+#include <thrust/copy.h>
+#include <thrust/count.h>
+#include <thrust/device_ptr.h>
+#include <thrust/distance.h>
+#include <thrust/extrema.h>
+#include <thrust/fill.h>
+#include <thrust/iterator/counting_iterator.h>
+#include <thrust/replace.h>
+#include <thrust/scan.h>
+#include <thrust/sort.h>
 #include <xgboost/host_device_vector.h>
 #include <xgboost/logging.h>
 

--- a/src/tree/gpu_hist/histogram.cu
+++ b/src/tree/gpu_hist/histogram.cu
@@ -3,6 +3,9 @@
  */
 #include <thrust/reduce.h>
 #include <thrust/iterator/transform_iterator.h>
+#include <thrust/device_ptr.h>
+#include <thrust/execution_policy.h>
+#include <thrust/functional.h>
 #include <algorithm>
 #include <ctgmath>
 #include <limits>

--- a/src/tree/gpu_hist/row_partitioner.cu
+++ b/src/tree/gpu_hist/row_partitioner.cu
@@ -1,6 +1,8 @@
 /*!
  * Copyright 2017-2021 XGBoost contributors
  */
+#include <thrust/fill.h>
+#include <thrust/iterator/counting_iterator.h>
 #include <thrust/iterator/discard_iterator.h>
 #include <thrust/iterator/transform_output_iterator.h>
 #include <thrust/sequence.h>

--- a/src/tree/gpu_hist/row_partitioner.cuh
+++ b/src/tree/gpu_hist/row_partitioner.cuh
@@ -2,6 +2,9 @@
  * Copyright 2017-2019 XGBoost contributors
  */
 #pragma once
+
+#include <thrust/fill.h>
+
 #include "xgboost/base.h"
 #include "../../common/device_helpers.cuh"
 

--- a/src/tree/updater_gpu_hist.cu
+++ b/src/tree/updater_gpu_hist.cu
@@ -3,6 +3,8 @@
  */
 #include <thrust/copy.h>
 #include <thrust/reduce.h>
+#include <thrust/execution_policy.h>
+#include <thrust/functional.h>
 #include <xgboost/tree_updater.h>
 #include <algorithm>
 #include <cmath>

--- a/tests/cpp/common/test_bitfield.cu
+++ b/tests/cpp/common/test_bitfield.cu
@@ -4,6 +4,7 @@
 #include <gtest/gtest.h>
 #include <thrust/copy.h>
 #include <thrust/device_vector.h>
+#include <thrust/fill.h>
 #include <vector>
 #include "../../../src/common/bitfield.h"
 #include "../../../src/common/device_helpers.cuh"

--- a/tests/cpp/common/test_device_helpers.cu
+++ b/tests/cpp/common/test_device_helpers.cu
@@ -4,6 +4,12 @@
 #include <cstddef>
 #include <cstdint>
 #include <thrust/device_vector.h>
+#include <thrust/execution_policy.h>
+#include <thrust/fill.h>
+#include <thrust/functional.h>
+#include <thrust/iterator/counting_iterator.h>
+#include <thrust/reduce.h>
+#include <thrust/sort.h>
 #include <vector>
 #include <xgboost/base.h>
 #include "../../../src/common/device_helpers.cuh"

--- a/tests/cpp/common/test_gpu_compressed_iterator.cu
+++ b/tests/cpp/common/test_gpu_compressed_iterator.cu
@@ -2,6 +2,7 @@
 #include "../../../src/common/device_helpers.cuh"
 #include "gtest/gtest.h"
 #include <algorithm>
+#include <thrust/copy.h>
 #include <thrust/device_vector.h>
 
 namespace xgboost {

--- a/tests/cpp/common/test_hist_util.cu
+++ b/tests/cpp/common/test_hist_util.cu
@@ -7,6 +7,9 @@
 #include <algorithm>
 #include <cmath>
 #include <thrust/device_vector.h>
+#include <thrust/copy.h>
+#include <thrust/sort.h>
+#include <thrust/unique.h>
 
 #include <xgboost/data.h>
 #include <xgboost/c_api.h>

--- a/tests/cpp/common/test_hist_util.h
+++ b/tests/cpp/common/test_hist_util.h
@@ -16,6 +16,9 @@
 
 #ifdef __CUDACC__
 #include <xgboost/json.h>
+
+#include <thrust/device_vector.h>
+
 #include "../../../src/data/device_adapter.cuh"
 #endif  // __CUDACC__
 

--- a/tests/cpp/common/test_host_device_vector.cu
+++ b/tests/cpp/common/test_host_device_vector.cu
@@ -5,6 +5,7 @@
 #include <gtest/gtest.h>
 #include <thrust/equal.h>
 #include <thrust/iterator/counting_iterator.h>
+#include <thrust/transform.h>
 
 #include "../../../src/common/device_helpers.cuh"
 #include <xgboost/host_device_vector.h>

--- a/tests/cpp/common/test_linalg.cu
+++ b/tests/cpp/common/test_linalg.cu
@@ -3,6 +3,8 @@
  */
 #include <gtest/gtest.h>
 
+#include <thrust/device_vector.h>
+
 #include "../../../src/common/linalg_op.cuh"
 #include "xgboost/generic_parameters.h"
 #include "xgboost/linalg.h"

--- a/tests/cpp/common/test_quantile.cu
+++ b/tests/cpp/common/test_quantile.cu
@@ -1,4 +1,18 @@
 #include <gtest/gtest.h>
+
+#include <thrust/copy.h>
+#include <thrust/device_ptr.h>
+#include <thrust/device_vector.h>
+#include <thrust/execution_policy.h>
+#include <thrust/fill.h>
+#include <thrust/host_vector.h>
+#include <thrust/iterator/counting_iterator.h>
+#include <thrust/iterator/zip_iterator.h>
+#include <thrust/scan.h>
+#include <thrust/sort.h>
+#include <thrust/transform.h>
+#include <thrust/tuple.h>
+
 #include "test_quantile.h"
 #include "../helpers.h"
 #include "../../../src/common/hist_util.cuh"

--- a/tests/cpp/common/test_ranking_utils.cu
+++ b/tests/cpp/common/test_ranking_utils.cu
@@ -1,4 +1,7 @@
 #include <gtest/gtest.h>
+
+#include <thrust/copy.h>
+
 #include "../../../src/common/ranking_utils.cuh"
 #include "../../../src/common/device_helpers.cuh"
 

--- a/tests/cpp/common/test_span.cu
+++ b/tests/cpp/common/test_span.cu
@@ -6,6 +6,8 @@
 #include <thrust/host_vector.h>
 #include <thrust/device_vector.h>
 #include <thrust/execution_policy.h>
+#include <thrust/copy.h>
+#include <thrust/memory.h>
 
 #include "../../../src/common/device_helpers.cuh"
 #include <xgboost/span.h>

--- a/tests/cpp/data/test_array_interface.h
+++ b/tests/cpp/data/test_array_interface.h
@@ -3,6 +3,8 @@
 #include <xgboost/data.h>
 #include <xgboost/json.h>
 #include <thrust/device_vector.h>
+#include <thrust/execution_policy.h>
+#include <thrust/sequence.h>
 
 #include <memory>
 #include "../../../src/common/bitfield.h"

--- a/tests/cpp/data/test_ellpack_page.cu
+++ b/tests/cpp/data/test_ellpack_page.cu
@@ -3,6 +3,9 @@
  */
 #include <xgboost/base.h>
 
+#include <thrust/device_vector.h>
+#include <thrust/copy.h>
+
 #include <utility>
 
 #include "../helpers.h"

--- a/tests/cpp/data/test_iterative_device_dmatrix.cu
+++ b/tests/cpp/data/test_iterative_device_dmatrix.cu
@@ -3,6 +3,9 @@
  */
 #include <gtest/gtest.h>
 
+#include <thrust/copy.h>
+#include <thrust/device_ptr.h>
+
 #include "../helpers.h"
 #include "../../../src/data/iterative_device_dmatrix.h"
 #include "../../../src/data/ellpack_page.cuh"

--- a/tests/cpp/data/test_simple_dmatrix.cu
+++ b/tests/cpp/data/test_simple_dmatrix.cu
@@ -3,6 +3,7 @@
 #include <xgboost/data.h>
 #include "../../../src/data/simple_dmatrix.h"
 
+#include <thrust/device_vector.h>
 #include <thrust/sequence.h>
 #include "../../../src/data/device_adapter.cuh"
 #include "../helpers.h"

--- a/tests/cpp/data/test_sparse_page_dmatrix.cu
+++ b/tests/cpp/data/test_sparse_page_dmatrix.cu
@@ -1,6 +1,10 @@
 // Copyright by Contributors
 
 #include <dmlc/filesystem.h>
+
+#include <thrust/copy.h>
+#include <thrust/device_vector.h>
+
 #include "../helpers.h"
 #include "../../../src/common/compressed_iterator.h"
 #include "../../../src/data/ellpack_page.cuh"

--- a/tests/cpp/objective/test_ranking_obj_gpu.cu
+++ b/tests/cpp/objective/test_ranking_obj_gpu.cu
@@ -2,6 +2,7 @@
  * Copyright 2019-2021 by XGBoost Contributors
  */
 #include <thrust/host_vector.h>
+#include <thrust/functional.h>
 
 #include "test_ranking_obj.cc"
 #include "../../../src/objective/rank_obj.cu"

--- a/tests/cpp/tree/gpu_hist/test_evaluate_splits.cu
+++ b/tests/cpp/tree/gpu_hist/test_evaluate_splits.cu
@@ -2,6 +2,9 @@
  * Copyright 2020-2022 by XGBoost contributors
  */
 #include <gtest/gtest.h>
+
+#include <thrust/device_vector.h>
+
 #include "../../../../src/tree/gpu_hist/evaluate_splits.cuh"
 #include "../../helpers.h"
 #include "../../histogram_helpers.h"

--- a/tests/cpp/tree/gpu_hist/test_histogram.cu
+++ b/tests/cpp/tree/gpu_hist/test_histogram.cu
@@ -1,4 +1,7 @@
 #include <gtest/gtest.h>
+
+#include <thrust/copy.h>
+
 #include <vector>
 
 #include "../../../../src/common/categorical.h"

--- a/tests/cpp/tree/test_constraints.cu
+++ b/tests/cpp/tree/test_constraints.cu
@@ -3,6 +3,7 @@
  */
 #include <gtest/gtest.h>
 #include <thrust/copy.h>
+#include <thrust/device_ptr.h>
 #include <thrust/device_vector.h>
 #include <cinttypes>
 #include <string>

--- a/tests/cpp/tree/test_gpu_hist.cu
+++ b/tests/cpp/tree/test_gpu_hist.cu
@@ -2,6 +2,7 @@
  * Copyright 2017-2021 XGBoost contributors
  */
 #include <gtest/gtest.h>
+#include <thrust/copy.h>
 #include <thrust/device_vector.h>
 #include <thrust/host_vector.h>
 #include <dmlc/filesystem.h>


### PR DESCRIPTION
This PR adds missing Thrust includes. [Version 1.16 of Thrust](https://github.com/NVIDIA/thrust/releases/tag/1.16.0) removed some internal header inclusions that were implicitly (and improperly) relied on by some downstream applications. This PR should ensure compatibility with versions 1.16+ of Thrust by explicitly including the headers used in each file.